### PR TITLE
Feature/organize requirements

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,9 +8,6 @@ dependencies:
   - pandas
   - xlrd  # to support pandas.read_excel()
   - openpyxl
-  - pypandoc
-  - pyyaml
-  - appdirs
   # TEST
   - pytest
   - coverage

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+-r requirements-test.txt
+
+black
+flake8
+flake8-comprehensions

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,6 @@
+-r requirements.txt
+
+xlrd
+pytest
+coverage
+pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+ numpy
+ pandas
+ openpyxl
+ 


### PR DESCRIPTION
Easy one: simple clean-up and reorganization of dependencies, as a first step toward re-establishing functioning test & build pipelines.

The only change is : I made a suite of requirements-*.txt files ; these simply didn't exist before. 

Once this is merged, we can start playing with e.g. GitHub actions (or whatever other CI), which will be able to use `pip install -r requirements-test.txt` to install dependencies