### PR TITLE
Proposal to make headers work better.

### DIFF
--- a/startables/startables.py
+++ b/startables/startables.py
@@ -454,6 +454,8 @@ class Bundle:
      * are understood as having a common context, in particular when evaluating expressions.
     """
 
+    MIN_BUNDLE_SEPARATOR = 3
+
     def __init__(self, tables: Iterable[Table], origin: Optional[TableOrigin] = None):
         self._tables = list(tables)
         self.origin = origin
@@ -551,7 +553,9 @@ class Bundle:
         max_num_cols = max(len(t.col_names) for t in self._tables)
         if header:
             stream.write(header.rstrip())
-            stream.write('\n\n')
+            stream.write('\n')
+            stream.write(sep * Bundle.MIN_BUNDLE_SEPARATOR)
+            stream.write('\n')
 
         for t in self._tables:
             t.to_csv(stream, sep=sep, num_cols=max_num_cols)
@@ -651,7 +655,7 @@ def read_csv(filepath_or_buffer: Union[str, pathlib.Path, TextIO], sep: str = ';
         return df_block
 
     # re thingies used...
-    BLOCK_SEPARATOR = re.compile(r'(\n[SEP]{3,})+\n'.replace('SEP', sep))  # escape hell if f-string
+    BLOCK_SEPARATOR = re.compile(r'(\n[SEP]{MIN,})+\n'.replace('SEP', sep).replace('MIN', str(Bundle.MIN_BUNDLE_SEPARATOR)))  # escape hell if f-string
     TABLE_MARKER = re.compile(r'^\*{2}(\w*)')
     DIRECTIVE_MARKER = re.compile(r'^\*{3}(\w*)')
     TEMPLATE_MARKER = re.compile(r'^:{1,3}(\w*)')

--- a/startables/test/input/example_header.csv
+++ b/startables/test/input/example_header.csv
@@ -1,0 +1,20 @@
+Header
+Date:;26-11-2019
+Description:;Example csv with a header
+;;;;
+**layer_cake;;;;
+birthday_party
+height;segment_top;diameter;colour
+mm;mm;cm;text
+0;50;25;pink
+50;65;15;white
+65;75;15;blue
+
+**beverages;;;
+birthday_party
+name;volume;quantity
+text;mL;-
+orange juice;500;3
+sparkling water;1000;5
+soda;350;24
+rasperberry soda;350;24


### PR DESCRIPTION
I propose that after a header, a 'block separator' will need to be added.  See tests/input/example_header.csv for an example

When this isn't the case, then no tables can be read into a bundle from a csv with a header produced by Bundle.to_csv

Also added a variable to define a minimum block separator.  This was implicitly implied previously in the  BLOCK_SEPARATOR (~line 658) regular expression.  

What do you think?  Open to suggestions!

Note that reading in an excel file with headers does not have any issues.