### PR TITLE
Fixed docx package name in environment file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pandas
   - xlrd  # to support pandas.read_excel()
   - openpyxl
-  - docx
+  - python-docx
   # TEST
   - pytest
   - coverage


### PR DESCRIPTION
Docx package is installed under the name [python-docx](https://anaconda.org/conda-forge/python-docx)