### PR TITLE
Using openpyxl to read xlsx files

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,13 @@ In a coming release, the following items are lined up to be...
 
 * {...crickets chirping...}
 
+
+### 0.8.5 - 2020-17-12
+
+#### Fixed
+
+* `pandas.read_excel()` is now called with `engine='openpyxl'` to ensure compalibility with `.xlsx` files
+
 ### 0.8.4 - 2019-12-05
 
 #### Fixed

--- a/startables/__init__.py
+++ b/startables/__init__.py
@@ -2,4 +2,4 @@ from startables.startables import Table, Bundle, read_csv, read_excel, ColumnMet
 from startables.readers.bulk import read_bulk
 from startables.readers.word import import_from_word
 
-__version__ = "0.8.4"
+__version__ = "0.8.5"

--- a/startables/startables.py
+++ b/startables/startables.py
@@ -738,7 +738,7 @@ def _make_single_dataframe_from_excel_workbook(io) -> pd.DataFrame:
     """
     # Produce dictionary whose values are the data frames for each sheet
     dfs_by_sheet = pd.read_excel(io, sheet_name=None, header=None, na_values=[''],
-                                 keep_default_na=False)
+                                 keep_default_na=False, engine='openpyxl')
     # We need to append a blank row to each data frame since by specification, startables
     # are separated by empty lines
     for sheet_name, df in dfs_by_sheet.items():


### PR DESCRIPTION
Pandas defaults to xlrd when loading excel files, but xlrd version 2.0 is incompatible with `.xlsx` files. Forcing it to use openpyxl instead solves the issue.